### PR TITLE
LINE連携（LINE-first / Web-first 両対応）を追加

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -4,8 +4,12 @@ class ApplicationController < ActionController::Base
 
   before_action :configure_permitted_parameters, if: :devise_controller?
 
-  def after_sign_in_path_for(_resource)
-    mypage_path
+  def after_sign_in_path_for(resource)
+    if (token = session.delete(:pending_line_link_token)).present?
+      line_link_path(token: token)
+    else
+      stored_location_for(resource) || mypage_path
+    end
   end
 
   protected

--- a/app/controllers/line/auth_controller.rb
+++ b/app/controllers/line/auth_controller.rb
@@ -1,0 +1,88 @@
+class Line::AuthController < ApplicationController
+  before_action :authenticate_user!
+
+  LINE_AUTHORIZE_URL = "https://access.line.me/oauth2/v2.1/authorize"
+  LINE_TOKEN_URL = "https://api.line.me/oauth2/v2.1/token"
+  LINE_PROFILE_URL = "https://api.line.me/v2/profile"
+
+  def connect
+    state = SecureRandom.hex(16)
+    session[:line_oauth_state] = state
+
+    query = {
+      response_type: "code",
+      client_id: ENV.fetch("LINE_LOGIN_CLIENT_ID"),
+      redirect_uri: line_callback_url,
+      state: state,
+      scope: "profile",
+    }.to_query
+
+    redirect_to "#{LINE_AUTHORIZE_URL}?#{query}", allow_other_host: true
+  end
+
+  def callback
+    if params[:state] != session.delete(:line_oauth_state)
+      return redirect_to account_setting_path, alert: "LINE連携に失敗しました(不正なリクエスト)."
+    end
+
+    if params[:error].present?
+      return redirect_to account_setting_path, alert: "LINE連携をキャンセルしました."
+    end
+
+    token_data = exchange_code(params[:code])
+    unless token_data
+      return redirect_to account_setting_path, alert: "LINE連携に失敗しました(トークン取得エラー)."
+    end
+
+    profile = fetch_profile(token_data["access_token"])
+    unless profile
+      return redirect_to account_setting_path, alert: "LINEプロフィールの取得に失敗しました."
+    end
+
+    line_user_id = profile["userId"]
+
+    if User.where.not(id: current_user.id).exists?(line_user_id: line_user_id)
+      return redirect_to account_setting_path, alert: "このLINEアカウントはすでに別のPrenessアカウントと連携済みです."
+    end
+
+    current_user.update!(line_user_id: line_user_id)
+    redirect_to account_setting_path, notice: "LINEとの連携が完了しました."
+  end
+
+  def disconnect
+    current_user.update!(line_user_id: nil)
+    redirect_to account_setting_path, notice: "LINE連携を解除しました."
+  end
+
+  private
+
+  def line_callback_url
+    "#{ENV.fetch('LINE_LINK_BASE_URL')}/line/callback"
+  end
+
+  def exchange_code(code)
+    resp = Faraday.post(LINE_TOKEN_URL) do |req|
+      req.headers["Content-Type"] = "application/x-www-form-urlencoded"
+      req.body = {
+        grant_type: "authorization_code",
+        code: code,
+        redirect_uri: line_callback_url,
+        client_id: ENV.fetch("LINE_LOGIN_CLIENT_ID"),
+        client_secret: ENV.fetch("LINE_LOGIN_CLIENT_SECRET"),
+      }.to_query
+    end
+    resp.success? ? JSON.parse(resp.body) : nil
+  rescue StandardError
+    nil
+  end
+
+  def fetch_profile(access_token)
+    resp = Faraday.get(LINE_PROFILE_URL) do |req|
+      req.headers["Authorization"] = "Bearer #{access_token}"
+    end
+    resp.success? ? JSON.parse(resp.body) : nil
+  rescue StandardError
+    nil
+  end
+end
+

--- a/app/controllers/line_links_controller.rb
+++ b/app/controllers/line_links_controller.rb
@@ -1,0 +1,33 @@
+class LineLinksController < ApplicationController
+  before_action :store_line_token_and_authenticate
+
+  def show
+    token = params[:token].to_s
+    link_session = LineLinkSession.pending_valid.find_by(link_token: token)
+
+    if link_session.nil?
+      @error = "このリンクは無効または期限切れです. LINEから再度友だち追加してください."
+      render :error, status: :unprocessable_entity and return
+    end
+
+    if link_session.user_id.present? && link_session.user_id != current_user.id
+      @error = "このリンクはすでに別のアカウントで使用されています."
+      render :error, status: :unprocessable_entity and return
+    end
+
+    nonce = SecureRandom.uuid
+    link_session.update!(nonce: nonce, user_id: current_user.id)
+
+    redirect_to "https://access.line.me/dialog/bot/accountLink?linkToken=#{token}&nonce=#{nonce}", allow_other_host: true
+  end
+
+  private
+
+  def store_line_token_and_authenticate
+    if !user_signed_in? && params[:token].present?
+      session[:pending_line_link_token] = params[:token]
+    end
+    authenticate_user!
+  end
+end
+

--- a/app/models/line_link_session.rb
+++ b/app/models/line_link_session.rb
@@ -1,0 +1,9 @@
+class LineLinkSession < ApplicationRecord
+  belongs_to :user, optional: true
+
+  scope :pending_valid, -> { where(status: "pending").where("expires_at > ?", Time.current) }
+
+  validates :line_user_id, presence: true
+  validates :link_token, presence: true, uniqueness: true
+end
+

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -8,11 +8,16 @@ class User < ApplicationRecord
   has_many :purchases, dependent: :destroy
   has_many :completed_purchases, -> { completed }, class_name: "Purchase"
   has_many :purchased_mocks, through: :completed_purchases, source: :mock
+  has_many :line_link_sessions, dependent: :nullify
 
   validates :terms_agreed, acceptance: { accept: true }, on: :create
 
   def purchased?(mock)
     purchases.completed.exists?(mock: mock)
+  end
+
+  def line_linked?
+    line_user_id.present?
   end
 end
 

--- a/app/views/account_settings/show.html.erb
+++ b/app/views/account_settings/show.html.erb
@@ -101,6 +101,26 @@
         </div>
 
       </div>
+
+      <%# LINE連携 %>
+      <div class="bg-white rounded-2xl shadow-sm border border-gray-100 p-6 mt-6">
+        <div class="flex items-center justify-between mb-4">
+          <h2 class="text-base font-semibold text-gray-800">LINE連携</h2>
+          <% if current_user.line_linked? %>
+            <span class="text-xs text-green-600 font-medium">連携済み</span>
+          <% end %>
+        </div>
+        <% if current_user.line_linked? %>
+          <p class="text-sm text-gray-500 mb-4">PrenessとLINEが連携されています. 学習通知をLINEで受け取れます.</p>
+          <%= button_to "LINE連携を解除する", line_disconnect_path, method: :delete,
+                        class: "text-sm text-red-500 hover:text-red-700 underline bg-transparent border-0 cursor-pointer p-0",
+                        data: { turbo_confirm: "LINE連携を解除しますか?" } %>
+        <% else %>
+          <p class="text-sm text-gray-500 mb-4">LINEと連携すると, 学習通知をLINEで受け取ることができます.</p>
+          <%= link_to "LINEと連携する", line_connect_path,
+                      class: "inline-block bg-[#06C755] hover:bg-[#05b34c] text-white text-sm font-bold px-5 py-2.5 rounded-xl transition" %>
+        <% end %>
+      </div>
     </div>
   </main>
 </div>

--- a/app/views/line_links/error.html.erb
+++ b/app/views/line_links/error.html.erb
@@ -1,0 +1,5 @@
+<div class="max-w-md mx-auto mt-16 text-center px-4">
+  <p class="text-red-600 font-semibold text-sm"><%= @error %></p>
+  <%= link_to "トップへ戻る", root_path, class: "mt-4 inline-block text-teal-600 underline text-sm" %>
+</div>
+

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -69,6 +69,11 @@ Rails.application.routes.draw do
       resources :exercises, only: [:create]
     end
   end
+
+  get "line/link", to: "line_links#show", as: :line_link
+  get "line/connect", to: "line/auth#connect", as: :line_connect
+  get "line/callback", to: "line/auth#callback", as: :line_callback
+  delete "line/disconnect", to: "line/auth#disconnect", as: :line_disconnect
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
 
   # Reveal health status on /up that returns 200 if the app boots with no exceptions, otherwise 500.

--- a/db/migrate/20260426140000_add_line_user_id_to_users.rb
+++ b/db/migrate/20260426140000_add_line_user_id_to_users.rb
@@ -1,0 +1,7 @@
+class AddLineUserIdToUsers < ActiveRecord::Migration[8.0]
+  def change
+    add_column :users, :line_user_id, :string
+    add_index :users, :line_user_id, unique: true
+  end
+end
+

--- a/db/migrate/20260426140100_create_line_link_sessions.rb
+++ b/db/migrate/20260426140100_create_line_link_sessions.rb
@@ -1,0 +1,21 @@
+class CreateLineLinkSessions < ActiveRecord::Migration[8.0]
+  def change
+    create_table :line_link_sessions do |t|
+      t.string :line_user_id, null: false
+      t.string :link_token, null: false
+      t.string :nonce
+      t.bigint :user_id
+      t.string :status, null: false, default: "pending"
+      t.datetime :expires_at, null: false
+
+      t.timestamps
+    end
+
+    add_index :line_link_sessions, :link_token, unique: true
+    add_index :line_link_sessions, :nonce, unique: true, where: "nonce IS NOT NULL"
+    add_index :line_link_sessions, :line_user_id
+    add_index :line_link_sessions, :user_id
+    add_foreign_key :line_link_sessions, :users, column: :user_id
+  end
+end
+


### PR DESCRIPTION
## 概要
LINE-first（友だち追加→連携URL→ログイン/新規登録→アカウント連携）と, Web-first（ログイン済みユーザーがアカウント設定からLINE Loginで直接連携）の両方向に対応したLINE連携機能を追加する.

## 変更内容
- usersに `line_user_id` を追加
- `line_link_sessions` テーブルを追加
- LINE-first: `GET /line/link?token=...` を追加（ログイン必須・nonce保存・accountLinkへリダイレクト）
- Web-first: `GET /line/connect` → `GET /line/callback` を追加（LINE Login OAuth）
- `DELETE /line/disconnect` を追加（連携解除）
- アカウント設定画面にLINE連携/解除のUIを追加
- ログイン後の遷移を `stored_location_for` 優先にし, 連携トークンをセッション保持して連携を継続できるようにする

## 環境変数
- `LINE_LOGIN_CLIENT_ID`
- `LINE_LOGIN_CLIENT_SECRET`
- `LINE_LINK_BASE_URL`（例: `https://preness.up.railway.app`）

## LINE Developers設定
- LINE Loginチャネルを作成
- Callback URL: `{LINE_LINK_BASE_URL}/line/callback`

## 動作確認
- LINE-first: `/line/link?token=...` を未ログインで開く→ログイン/新規登録後にaccountLinkへ遷移できる
- Web-first: アカウント設定の「LINEと連携する」→LINE Login→連携完了が表示される
- 既に別ユーザーに紐付いているLINEは連携できない